### PR TITLE
Retransmit Packet Loss

### DIFF
--- a/bootloader.py
+++ b/bootloader.py
@@ -125,7 +125,6 @@ class Bootloader:
         by computing a checksum.
 
         """
-        unreceived_packets = []
         for i, address in enumerate(
             range(self.ih.minaddr(), self.ih.minaddr() + self.size_bytes(), 8)
         ):


### PR DESCRIPTION
Added a feature to the bootloader code that detects and retransmits lost packets during updates. Now, after processing a chunk of data (64 bits), the bootloader checks for any lost packets and sends them again. This ensures that all data packets are successfully received, improving the reliability of firmware updates.